### PR TITLE
Fix bug that caused bitmap to not display when y > height

### DIFF
--- a/src/ArduinoGraphics.cpp
+++ b/src/ArduinoGraphics.cpp
@@ -236,7 +236,7 @@ void ArduinoGraphics::bitmap(const uint8_t* data, int x, int y, int width, int h
     return;
   }
 
-  if ((data == NULL) || ((x + width) < 0) || ((y + height) < 0) || (x > _width) || (y > height)) {
+  if ((data == NULL) || ((x + width) < 0) || ((y + height) < 0) || (x > _width) || (y > _height)) {
     // offscreen
     return;
   }


### PR DESCRIPTION
Use of incorrect variable name caused the bitmap to not display when the y position was greater than the bitmap height.