### PR TITLE
Made TextColor independent of Stroke

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,8 +10,8 @@ Font	KEYWORD1
 Image	KEYWORD1
 
 ##########################################
-# Methods and Functions 
-##########################################	
+# Methods and Functions
+##########################################
 
 begin	KEYWORD2
 end	KEYWORD2
@@ -28,6 +28,8 @@ fill	KEYWORD2
 noFill	KEYWORD2
 stroke	KEYWORD2
 noStroke	KEYWORD2
+setTextColor	KEYWORD2
+noTextColor	KEYWORD2
 
 line	KEYWORD2
 point	KEYWORD2

--- a/src/ArduinoGraphics.h
+++ b/src/ArduinoGraphics.h
@@ -56,6 +56,9 @@ public:
   void stroke(uint8_t r, uint8_t g, uint8_t b);
   void stroke(uint32_t color);
   void noStroke();
+  void setTextColor(uint8_t r, uint8_t g, uint8_t b);
+  void setTextColor(uint32_t color);
+  void noTextColor();
 
   //virtual void arc(int x, int y, int width, int height, int start, int stop);
   //virtual void ellipse(int x, int y, int width, int height);
@@ -90,6 +93,7 @@ public:
 
 protected:
   virtual void bitmap(const uint8_t* data, int x, int y, int width, int height);
+  virtual void text_bitmap(const uint8_t* data, int x, int y, int width, int height);
   virtual void imageRGB(const Image& img, int x, int y, int width, int height);
   virtual void imageRGB24(const Image& img, int x, int y, int width, int height);
   virtual void imageRGB16(const Image& img, int x, int y, int width, int height);
@@ -108,6 +112,7 @@ private:
   uint8_t _fillR, _fillG, _fillB;
   uint8_t _strokeR, _strokeG, _strokeB;
 
+  bool _text;
   String _textBuffer;
   uint8_t _textR, _textG, _textB;
   int _textX;


### PR DESCRIPTION
A solution for #5 

Here I have tried to make text color completely independent of stroke color.
I have also added another clone bitmap function ( text_bitmap ) which uses the text color instead of stroke. I preserved the original bitmap function since I was not sure about its uses elsewhere. Now the text color can be set using both the setTextColor function or the BeginText functions with color inputs. 

Please review and suggest changes as you may see fit. 