### PR TITLE
Adjust spell check tool configuration to avoid false positive

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = ,
+ignore-words-list = mis
 check-filenames =
 check-hidden =
 skip = ./.git


### PR DESCRIPTION
The repository's CI system includes a check for commonly misspelled words.

The latest version of the [**codespell**](https://github.com/codespell-project/codespell) tool dependency used for this spell check is always used. This means that the results of the spell check can change as new versions of the tool are released. The recent codespell release introduced a false positive result:

https://github.com/arduino-libraries/ArduinoGraphics/actions/runs/5387324234/jobs/9778490628#step:4:17

```text
Error: ./examples/ASCIIDraw/ASCIIDraw.ino:29: mis ==> miss, mist
```

This is corrected by adding the word to the ignore list in the [**codespell** configuration file](https://github.com/codespell-project/codespell#using-a-config-file).