### PR TITLE
Fix: do not crash on ASCII chars with a numeric value exceeding 127.

### DIFF
--- a/src/ArduinoGraphics.cpp
+++ b/src/ArduinoGraphics.cpp
@@ -238,7 +238,7 @@ void ArduinoGraphics::text(const char* str, int x, int y)
   }
 
   while (*str) {
-    int c = *str++;
+    uint8_t const c = (uint8_t)*str++;
 
     if (c == '\n') {
       y += _font->height;


### PR DESCRIPTION
When writing a text this library supports 255 different characters. However, due to the function signature of `ArduinoGraphics::text(const char* str, ...` which passes a `const char*` value is interpreted as a negative value when a ASCII character with a numeric value exceeding 127 is passed to this function. Subsequently this leads to an array out-of-bounds access and a application crash.

By casting to `uint8_t` we ensure that we obtain the correct (positive) numeric value for subsequently accessing the bitmap without array-out-of-bounds access.
 
Minimal failing test application (crashes upon execution):
```C++
#include "ArduinoGraphics.h"
#include "Arduino_LED_Matrix.h"

ArduinoLEDMatrix matrix;

void setup()
{
  matrix.begin();

  float const temperature = 25.3f;
  float const humidity = 47.6f;
  float const pressure = 1.23f;

  char msg[64] = {0};
  snprintf(msg, sizeof(msg), "%0.1f °C, %0.1f %%, %0.2f atm", temperature, humidity, pressure);

  matrix.beginDraw();

  matrix.stroke(0xFFFFFFFF);
  matrix.textScrollSpeed(80);

  matrix.textFont(Font_5x7);
  matrix.beginText(0, 1, 0xFFFFFF);
  matrix.println(msg);
  matrix.endText(SCROLL_LEFT);

  matrix.endDraw();
}
```