### PR TITLE
Allow the fixed fonts to be scaled up.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -641,6 +641,41 @@ Nothing
 int h = YourScreen.textFontHeight();
 ```
 
+### `textSize()`
+
+#### Description
+
+Set a text scale factor
+
+#### Syntax
+
+```
+YourScreen.textSize(scale)
+YourScreen.textSize(scaleX, scaleY)
+```
+
+#### Parameters
+
+scale: scale factor used for both x and y
+scaleX: x scale factor
+scaleY: y scale factor
+
+#### Returns
+
+Nothing
+
+#### Example
+
+```
+YourScreen.beginDraw();
+YourScreen.clear();
+YourScreen.stroke(255, 255, 255);
+YourScreen.textFont(Font_5x7);
+YourScreen.textSize(5);
+YourScreen.text("abc", 0, 1);
+YourScreen.endDraw();
+```
+
 ### `set()`
 
 #### Description

--- a/examples/ASCIIDraw/ASCIIDraw.ino
+++ b/examples/ASCIIDraw/ASCIIDraw.ino
@@ -14,8 +14,9 @@
 
 #include <ArduinoGraphics.h>
 
-const byte canvasWidth = 61;
-const byte canvasHeight = 27;
+const byte fontSize = 3;
+const byte canvasWidth = fontSize * (5 * 7) + 26;
+const byte canvasHeight = fontSize * 7 + 20;
 
 class ASCIIDrawClass : public ArduinoGraphics {
   public:
@@ -85,6 +86,7 @@ void setup() {
   ASCIIDraw.stroke('@', 0, 0);
   const char text[] = "ARDUINO";
   ASCIIDraw.textFont(Font_5x7);
+  ASCIIDraw.textSize(fontSize);
   const byte textWidth = strlen(text) * ASCIIDraw.textFontWidth();
   const byte textHeight = ASCIIDraw.textFontHeight();
   const byte textX = (canvasWidth - textWidth) / 2;

--- a/src/ArduinoGraphics.h
+++ b/src/ArduinoGraphics.h
@@ -70,6 +70,8 @@ public:
   virtual void text(const char* str, int x = 0, int y = 0);
   virtual void text(const String& str, int x = 0, int y = 0) { text(str.c_str(), x, y); }
   virtual void textFont(const Font& which);
+  virtual void textSize(uint8_t s) {textSize(s, s);}
+  virtual void textSize(uint8_t sx, uint8_t sy);
 
   virtual int textFontWidth() const;
   virtual int textFontHeight() const;
@@ -91,7 +93,8 @@ public:
   virtual void textScrollSpeed(unsigned long speed = 150);
 
 protected:
-  virtual void bitmap(const uint8_t* data, int x, int y, int width, int height);
+  virtual void bitmap(const uint8_t* data, int x, int y, int w, int h, uint8_t scale_x = 1, 
+                      uint8_t scale_y = 1);
   virtual void imageRGB(const Image& img, int x, int y, int width, int height);
   virtual void imageRGB24(const Image& img, int x, int y, int width, int height);
   virtual void imageRGB16(const Image& img, int x, int y, int width, int height);
@@ -114,6 +117,8 @@ private:
   uint8_t _textR, _textG, _textB;
   int _textX;
   int _textY;
+  uint8_t _textSizeX;
+  uint8_t _textSizeY;
   unsigned long _textScrollSpeed;
 };
 


### PR DESCRIPTION
This hopefully addresses issue #3 

On larger displays, the two built in fonts are almost invisible. One possible solution is to supply some larger fonts.

Another approach is to do, like several TFT display drivers do and allow you to scale the system fixed fonts up to a larger size.  Decided this was the easiest approach, and did a quick implementation of it.  Like the Adafruit displays, I allowed you to set different scale factors for X and Y.

I added a scaledBitmap function which is a modified version of the current bitmap function.  I also changed all of the text functions to use it.  I left the unscalled version of the API, although I have it simply call the scaled version with scales 1 and 1, as since these methods are virtual, potentially some other subclasses might use and/or implement their own version.

Updated the textFontWidth and textFontHeight to multiply  the height * the scale as the one example sketch here needs it.

I also updated the sketch to scale the canvas to take the font size into account. This appears to work with the changes and

I have not used or tested the scroll code.  Its sizing should be updated teh same way the test sketch was with the changes with the textFontWidth and textFontHeight changes