### PR TITLE
Declare compatibility with renesas_uno architecture

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Core graphics library for Arduino.
 paragraph=Based on the Processing API.
 category=Display
 url=http://github.com/arduino-libraries/ArduinoGraphics
-architectures=samd
+architectures=samd,renesas_uno
 includes=ArduinoGraphics.h


### PR DESCRIPTION
Declare compatability with `renesas_uno` architecture in `library.properties`.

Closes https://github.com/arduino-libraries/ArduinoGraphics/issues/48