### PR TITLE
Fix scroll trail clearing bugs

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = mis
+ignore-words-list = cleary,mis
 check-filenames =
 check-hidden =
 skip = ./.git

--- a/src/ArduinoGraphics.cpp
+++ b/src/ArduinoGraphics.cpp
@@ -458,7 +458,7 @@ void ArduinoGraphics::endText(int scrollDirection)
       beginDraw();
       int const text_x = _textX - i;
       text(_textBuffer, text_x, _textY);
-      bitmap(_font->data[0x20], text_x - 1, _textY, 1, _font->height, _textSizeX, _textSizeY);
+      bitmap(_font->data[0x20], text_x + _textBuffer.length() * _font->width, _textY, 1, _font->height, _textSizeX, _textSizeY);
       endDraw();
 
       delay(_textScrollSpeed);
@@ -482,7 +482,7 @@ void ArduinoGraphics::endText(int scrollDirection)
       beginDraw();
       int const text_y = _textY - i;
       text(_textBuffer, _textX, text_y);
-      bitmap(_font->data[0x20], _textX, text_y - 1, _font->width, 1, _textSizeX, _textSizeY);
+      bitmap(_font->data[0x20], _textX, text_y + _font->height, _font->width, 1, _textSizeX, _textSizeY);
       endDraw();
 
       delay(_textScrollSpeed);

--- a/src/ArduinoGraphics.cpp
+++ b/src/ArduinoGraphics.cpp
@@ -448,17 +448,21 @@ void ArduinoGraphics::endText(int scrollDirection)
   uint8_t strokeG = _strokeG;
   uint8_t strokeB = _strokeB;
 
-
-  stroke(_textR, _textG, _textB);
-
   if (scrollDirection == SCROLL_LEFT) {
     int scrollLength = _textBuffer.length() * textFontWidth() + _textX;
 
     for (int i = 0; i < scrollLength; i++) {
       beginDraw();
+
       int const text_x = _textX - i;
+      stroke(_textR, _textG, _textB);
       text(_textBuffer, text_x, _textY);
-      bitmap(_font->data[0x20], text_x + _textBuffer.length() * _font->width, _textY, 1, _font->height, _textSizeX, _textSizeY);
+
+      // clear previous position
+      const int clearX = text_x + _textBuffer.length() * _font->width;
+      stroke(_backgroundR, _backgroundG, _backgroundB);
+      line(clearX, _textY, clearX, _textY + _font->height - 1);
+
       endDraw();
 
       delay(_textScrollSpeed);
@@ -468,9 +472,18 @@ void ArduinoGraphics::endText(int scrollDirection)
 
     for (int i = 0; i < scrollLength; i++) {
       beginDraw();
+
       int const text_x = _textX - (scrollLength - i - 1);
+      stroke(_textR, _textG, _textB);
       text(_textBuffer, text_x, _textY);
+
+      // clear previous position
+      const int clearX = text_x - 1;
+      stroke(_backgroundR, _backgroundG, _backgroundB);
+      line(clearX, _textY, clearX, _textY + _font->height - 1);
+
       bitmap(_font->data[0x20], text_x - 1, _textY, 1, _font->height, _textSizeX, _textSizeY);
+
       endDraw();
 
       delay(_textScrollSpeed);
@@ -480,9 +493,16 @@ void ArduinoGraphics::endText(int scrollDirection)
 
     for (int i = 0; i < scrollLength; i++) {
       beginDraw();
+
       int const text_y = _textY - i;
+      stroke(_textR, _textG, _textB);
       text(_textBuffer, _textX, text_y);
-      bitmap(_font->data[0x20], _textX, text_y + _font->height, _font->width, 1, _textSizeX, _textSizeY);
+
+      // clear previous position
+      const int clearY = text_y + _font->height;
+      stroke(_backgroundR, _backgroundG, _backgroundB);
+      line(_textX, clearY, _textX + (_font->width * _textBuffer.length()) - 1, clearY);
+
       endDraw();
 
       delay(_textScrollSpeed);
@@ -492,8 +512,16 @@ void ArduinoGraphics::endText(int scrollDirection)
 
     for (int i = 0; i < scrollLength; i++) {
       beginDraw();
+
       int const text_y = _textY - (scrollLength - i - 1);
+      stroke(_textR, _textG, _textB);
       text(_textBuffer, _textX, text_y);
+
+      // clear previous position
+      const int clearY = text_y - 1;
+      stroke(_backgroundR, _backgroundG, _backgroundB);
+      line(_textX, clearY, _textX + (_font->width * _textBuffer.length()) - 1, clearY);
+
       bitmap(_font->data[0x20], _textX, text_y - 1, _font->width, 1, _textSizeX, _textSizeY);
       endDraw();
 
@@ -501,6 +529,7 @@ void ArduinoGraphics::endText(int scrollDirection)
     }
   } else {
     beginDraw();
+    stroke(_textR, _textG, _textB);
     text(_textBuffer, _textX, _textY);
     endDraw();
   }


### PR DESCRIPTION
The `endText` function has the capability to scroll the printed text. In order to ensure artifacts are not left behind on the display while scrolling, the library must clear the pixels at the previous location of the text after each frame of the scrolling animation (https://github.com/arduino-libraries/ArduinoGraphics/pull/36).

Multiple bugs were found in the code that performs scroll trail clearing, which could cause a trail of artifacts to be left behind on the display when text was scrolled under certain conditions (https://github.com/arduino-libraries/ArduinoGraphics/issues/50). These bugs may not be immediately apparent to users because pixels are not populated at the edges of some character bitmaps, and thus such characters provide incidental self scroll trail clearing.

The following fixes are proposed by this pull request:

## Correct text scroll trail clearing coordinates calculation for left and up directions

Previously, the code to handle this clearing incorrectly calculated the clearing coordinates for the leftwards (`SCROLL_LEFT`) and upwards (`SCROLL_UP`) scroll directions, having two separate problems:

- The offset was subtracted rather than added.
- An offset of 1 was used, which did not consider the width/height of the text.

## Clear trail for full string width when scrolling text vertically

Previously, the code to handle this clearing for vertical scrolling only cleared a single character's width. This meant that scroll trail clearing was only done for the first character in the string.

Previously the [`ArduinoGraphics::bitmap` function](https://github.com/arduino-libraries/ArduinoGraphics/blob/589b6220e2ce1ddc71f6532d7687ece3aa8dfa2c/src/ArduinoGraphics.cpp#L294) was used by the clearing code. That approach was reasonable for clearing the scroll trail of a single character, but due to the function's eight pixel width limitation, it is not suitable to use with strings. In this application where a line of arbitrary length, but only one pixel thick is needed, the [`ArduinoGraphics::line` function](https://github.com/arduino-libraries/ArduinoGraphics/blob/589b6220e2ce1ddc71f6532d7687ece3aa8dfa2c/src/ArduinoGraphics.cpp#L181) is the suitable tool. So the code is ported to using `ArduinoGraphics::line`.

NOTE: The calculations of the length of the clearing line will still be incorrect for multi-line strings. However, this is not a regression because it was also incorrect before this change. The scroll trail clearing code has never had any provisions for handling multi-line strings so adding such support is out of scope for this commit. In addition, the text scrolling code (not the scroll trail clearing code) has never correctly handled horizontal scrolling of multi-line strings, so until that is fixed it is only the lack of correct scroll trail clearing for vertical scrolling that is impactful to users.

## Outstanding defects

### Multi-line strings

As was the case before the changes proposed by this PR, scroll trail clearing is not done correctly for multi-line strings. Since this is not a regression, and since the required changes to handle multi-line strings are not trivial, fixing this is considered out of scope for this PR.

The text scrolling code (not the scroll trail clearing code) has never correctly handled horizontal scrolling of multi-line strings, so until that is fixed it is only the lack of correct scroll trail clearing for vertical scrolling that is impactful to users.

#### Incorrect coordinates

Since it only considers the basic string length, the scroll trail clearing coordinates are incorrect for the leftwards (`SCROLL_LEFT`) and upwards (`SCROLL_UP`) scroll directions with multi-line strings.

#### Incorrect clearing line length

The clearing line length calculation for vertical scrolling is based on the basic string length and so will result in an overly long length for multi-line strings.

The clearing line length calculation for horizontal scrolling assumes the text will only be one character high so will result in a too short length for multi-line strings.

### Incomplete scrolling

The calculation for the distance of leftward and upward scrolling is off by one, which results in the text bitmap not being scrolled completely off the display.

This is a defect in the text scrolling code, not in scroll trail clearing. However, it results in what might appear to be an artifact during testing of this proposal, so I thought it worth mentioning here.

A fix has been proposed in https://github.com/arduino-libraries/ArduinoGraphics/pull/52.

---

Fixes https://github.com/arduino-libraries/ArduinoGraphics/issues/50