### PR TITLE
Correct scroll length for left and up directions

### DIFF
--- a/src/ArduinoGraphics.cpp
+++ b/src/ArduinoGraphics.cpp
@@ -452,7 +452,7 @@ void ArduinoGraphics::endText(int scrollDirection)
   stroke(_textR, _textG, _textB);
 
   if (scrollDirection == SCROLL_LEFT) {
-    int scrollLength = _textBuffer.length() * textFontWidth() + _textX;
+    int scrollLength = _textBuffer.length() * textFontWidth() + _textX + 1;
 
     for (int i = 0; i < scrollLength; i++) {
       beginDraw();
@@ -476,7 +476,7 @@ void ArduinoGraphics::endText(int scrollDirection)
       delay(_textScrollSpeed);
     }
   } else if (scrollDirection == SCROLL_UP) {
-    int scrollLength = textFontHeight() + _textY;
+    int scrollLength = textFontHeight() + _textY + 1;
 
     for (int i = 0; i < scrollLength; i++) {
       beginDraw();


### PR DESCRIPTION
Previously, the calculation for the distance of leftward and upward scrolling resulted in the text bitmap not being scrolled completely off the display.

For leftward scrolling, this would be noticeable in the case where the bitmap of the last character in the string had populated pixels on the rightmost column. For upward scrolling, this would be noticeable in the case where the bitmap of any character in the string had populated pixels on the bottom row.

## Demos

The incompletely scrolled pixels will not be distinguishable from the artifacts left by the unrelated bug https://github.com/arduino-libraries/ArduinoGraphics/issues/50, but can be seen if the fix from https://github.com/arduino-libraries/ArduinoGraphics/pull/51 is applied.

### `SCROLL_LEFT`

Prior to the change proposed here, the following sketch would result in the two pixels from the rightmost column of the `Font_4x6` `#` character bitmap would remaining on the display after scrolling:

```cpp
#include <ArduinoGraphics.h>
#include <Arduino_LED_Matrix.h>

ArduinoLEDMatrix matrix;

void setup() {
  matrix.begin();
  matrix.textFont(Font_4x6);
  matrix.textScrollSpeed(200);
}

void loop() {
  matrix.beginText(matrix.width(), 1, 0xFFFFFF);
  matrix.print("#");  // The bitmap for the Font_4x6 # character has two populated pixels on the rightmost column
  matrix.endText(SCROLL_LEFT);
}
```

### `SCROLL_UP`

Prior to the change proposed here, the following sketch would result in the pixel from the bottom row of the `Font_4x6` `(` character bitmap remaining on the display after scrolling:

```cpp
#include <ArduinoGraphics.h>
#include <Arduino_LED_Matrix.h>

ArduinoLEDMatrix matrix;

void setup() {
  matrix.begin();
  matrix.textFont(Font_4x6);
  matrix.textScrollSpeed(300);
}

void loop() {
  matrix.beginText(1, matrix.height(), 0xFFFFFF);
  matrix.print("(");  // The bitmap for the Font_4x6 ( character has a populated pixel on the bottom row
  matrix.endText(SCROLL_UP);
}
```