### PR TITLE
library.properties - set architectures=*

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Core graphics library for Arduino.
 paragraph=Based on the Processing API.
 category=Display
 url=http://github.com/arduino-libraries/ArduinoGraphics
-architectures=samd,renesas_uno
+architectures=*
 includes=ArduinoGraphics.h


### PR DESCRIPTION
I am not sure why it has been set to only samd and renesas_uno as there is nothing in this sketch that is architecturally specific.

It has also been used for Arduino Giga on MBED as well as on zephyr Likewise I have used it on Arduino Q, and yes we could add all of these to the list.

The current setting is such that the Arduino App Lab will not list this as a vailid library.  So in order to use it the user must jump through hoops. So forum thread: https://forum.arduino.cc/t/why-cant-i-add-the-arduinographics-library-in-arduino-app-lab/1419897/4 for more details.